### PR TITLE
always_run is deprecated. Use check_mode = no instead..

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ Changed
 
 - Update the role to DebOps Standards v0.2.1. [ypid_]
 
+- Fix Ansible 2.2 deprecation warnings. [brzhk]
+
 
 `debops.dhparam v0.1.2`_ - 2016-02-23
 -------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,7 +29,7 @@ Changed
 
 - Update the role to DebOps Standards v0.2.1. [ypid_]
 
-- Fix Ansible 2.2 deprecation warnings. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
 
 
 `debops.dhparam v0.1.2`_ - 2016-02-23

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,7 +29,8 @@ Changed
 
 - Update the role to DebOps Standards v0.2.1. [ypid_]
 
-- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher.
+  Support for older Ansible versions is dropped. [brzhk]
 
 
 `debops.dhparam v0.1.2`_ - 2016-02-23

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   author: 'Maciej Delmanowski, Robin Schneider'
   description: 'Manage one or multiple sets of Diffie-Hellman Ephemeral parameters'
   license: 'GPL-3.0'
-  min_ansible_version: '2.1.4'
+  min_ansible_version: '2.2.0'
 
   platforms:
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
   delegate_to: 'localhost'
   become: False
   run_once: True
-  always_run: True
+  check_mode: no
   tags: [ 'meta::provision' ]
 
 - name: Assert that required software is installed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
   delegate_to: 'localhost'
   become: False
   run_once: True
-  check_mode: no
+  check_mode: False
   tags: [ 'meta::provision' ]
 
 - name: Assert that required software is installed


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.